### PR TITLE
Remove unused mathlibjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,30 +12,29 @@
     "docker:run": "docker run -p 3000:3000 algorithm-builder"
   },
   "dependencies": {
-    "mathlibjs": "1.0.1",
+    "bcrypt": "^5.0.1",
+    "d3": "^7.0.0",
+    "dotenv": "^16.0.0",
     "express": "^4.17.3",
+    "jsonwebtoken": "^8.5.1",
+    "mathjs": "^9.5.0",
     "pg": "^8.7.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "mathjs": "^9.5.0",
-    "d3": "^7.0.0",
-    "socket.io": "^4.4.1",
-    "dotenv": "^16.0.0",
-    "bcrypt": "^5.0.1",
-    "jsonwebtoken": "^8.5.1"
+    "socket.io": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@babel/preset-react": "^7.16.7",
-    "webpack": "^5.70.0",
-    "webpack-dev-server": "^4.7.0",
     "babel-loader": "^8.2.2",
     "css-loader": "^6.7.1",
-    "style-loader": "^3.3.2",
     "html-webpack-plugin": "^5.5.0",
-    "webpack-node-externals": "^3.0.0",
-    "webpack-cli": "^4.9.2",
+    "jest": "^27.5.1",
     "nodemon": "^2.0.15",
-    "jest": "^27.5.1"
+    "style-loader": "^3.3.2",
+    "webpack": "^5.70.0",
+    "webpack-cli": "^4.9.2",
+    "webpack-dev-server": "^4.7.0",
+    "webpack-node-externals": "^3.0.0"
   }
 }


### PR DESCRIPTION
Remove unused dependency `mathlibjs` from `package.json`.

* **Dependencies**: Remove `mathlibjs` and reorder other dependencies to maintain alphabetical order.
* **DevDependencies**: Reorder dev dependencies to maintain alphabetical order.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Celebrum/algorithm-builder-app/pull/7?shareId=73058857-0a09-479b-bc1f-ea63247fe211).